### PR TITLE
Fix pathname expansion bug

### DIFF
--- a/get_cluster_config.sh
+++ b/get_cluster_config.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -f
+
 function usage {
   echo $1
   echo "USAGE: emr_clusterConf.sh -i <cluster-id> -r <region>"


### PR DESCRIPTION
"*" in EMR step arguments were picking up local files when using `get_cluster_config.sh`

This change disables pathname expansion to prevent that from happening.