### PR TITLE
We don't need SYNC_PROJECT_ID in the init script

### DIFF
--- a/integration/gradient-agent.sh
+++ b/integration/gradient-agent.sh
@@ -38,25 +38,4 @@ print(get_default_client().get_platform().value)
 EOD
 )
 
-if [[ -z $SYNC_PROJECT_ID ]]; then
-  SYNC_PROJECT_ID=$(python <<EOD
-from sync.${PLATFORM/-/} import get_cluster
-from sync.api.projects import get_projects
-
-cluster_response = get_cluster("$DB_CLUSTER_ID")
-if cluster_response.result:
-  cluster = cluster_response.result
-  if cluster['cluster_source'] == "JOB":
-    project_id = cluster.get('custom_tags', {}).get('sync:project-id')
-    if project_id:
-      print(project_id)
-EOD
-)
-fi
-
-if [[ -z $SYNC_PROJECT_ID ]]; then
-  >&2 echo "No project found for job running on cluster $DB_CLUSTER_ID"
-  exit 1
-fi
-
 sync-cli --debug $PLATFORM monitor-cluster $DB_CLUSTER_ID & disown


### PR DESCRIPTION
With `cluster_path` in projects (https://synccomputing.atlassian.net/browse/PROD-1295) we don't need to enforce SYNC_PROJECT_ID in the init script.