### PR TITLE
Cb 21 robust integration with record run job

### DIFF
--- a/integration/Gradient-Train-Job.py
+++ b/integration/Gradient-Train-Job.py
@@ -45,42 +45,86 @@ print(dbutils.widgets.get("Databricks Host").rstrip('\/'))
 # COMMAND ----------
 
 from sync.clients import databricks
+from sync.api import projects
 import orjson
 
-client = databricks.get_default_client()
-job = client.get_job(DATABRICKS_JOB_ID)
+databricks_client = databricks.get_default_client()
+job = databricks_client.get_job(DATABRICKS_JOB_ID)
 
 if "settings" not in job:
     print("Your job has been configured without a 'settings' block. This shouldn't happen! Please let the Sync team know you encountered this issue.")
 
 try: 
-    job_clusters = job["settings"]["job_clusters"][0]["new_cluster"]
-    #Find the original number of on-demand workers
-    original_ondemand = job_clusters["aws_attributes"]["first_on_demand"] or 0
-
-    #Update the cluster to all on-demand.  Answer will depend on if autoscaling is enabled
-    if("autoscale" in job_clusters.keys()):
-        updated_ondemand = job_clusters["autoscale"]["max_workers"] + 1
+    #default to job_clusters if they exist, else get tasks (which should always exist)
+    if "job_clusters" in job["settings"].keys():
+        key = "job_clusters"
+        clusters =  job["settings"].get("job_clusters")
     else:
-        updated_ondemand = (job_clusters["num_workers"] or 0) + 1
+        key = "tasks"
+        clusters = job["settings"].get("tasks")
+    #grabbing the relevant fields
+    for cluster in clusters:
+        cluster = cluster["new_cluster"]
+
+        if "aws_attributes" in cluster.keys():
+            cloud_attributes_key = "aws_attributes"
+        elif "azure_attributes" in cluster.keys():
+            cloud_attributes_key = "azure_attributes"
+
+        #Find the original number of on-demand workers
+        original_ondemand = cluster[cloud_attributes_key]["first_on_demand"] or 0
+
+        #Update the cluster to all on-demand.  Answer will depend on if autoscaling is enabled
+        if("autoscale" in cluster.keys()):
+            updated_ondemand = cluster["autoscale"]["max_workers"] + 1
+        else:
+            updated_ondemand = (cluster["num_workers"] or 0) + 1
 
 
-    print(f"first_on_demand: {original_ondemand or ''} -> {updated_ondemand or ''}")
+        print(f"first_on_demand: {original_ondemand or ''} -> {updated_ondemand or ''}")
 
 
-    job_clusters["aws_attributes"]["first_on_demand"] = updated_ondemand
-    new_settings = {"job_clusters": job["settings"]["job_clusters"]}
-    client.update_job(job_id=DATABRICKS_JOB_ID, new_settings=new_settings)
+        cluster[cloud_attributes_key]["first_on_demand"] = updated_ondemand
+        new_settings = {key: clusters}
+        databricks_client.update_job(job_id=DATABRICKS_JOB_ID, new_settings=new_settings)
     
 except KeyError as k:
-    print(f"We hit an error in the setup process. Currently, Gradient is only designed to work with Job clusters, not Task clusters. Contact the Sync Team for next steps. Error: {k}")    
-    
+    print(f"We hit an error in the setup process. Contact the Sync Team for next steps. Error: {k}")    
+
 
 # COMMAND ----------
 
 import json
 import requests
 import time
+from dateutil import parser
+from datetime import datetime, timezone
+from sync.clients import sync, databricks
+from sync.api import projects
+
+databricks_client = databricks.get_default_client()
+sync_client = sync.get_default_client()
+
+class RecommendationError(Exception):
+    "Raised something goes wrong with the generation of a GradientML Recommendation"
+
+    def __init__(self, error):
+        super().__init__("Recommendation Error: " + str(error))
+
+def get_custom_tag_value(key):
+    #this will not work correctly for jobs with multiple clusters
+    job = databricks_client.get_job(DATABRICKS_JOB_ID)
+    if clusters := (job["settings"].get("job_clusters") or job["settings"].get("tasks")):
+        val = clusters[0]["new_cluster"]["custom_tags"].get(key)
+    else:
+        raise(ValueError("This job does not have configured task-level or job-level compute clusters"))
+    return val
+
+if project_id := get_custom_tag_value("sync:project-id"):
+    if not projects.get_project(project_id).result["auto_apply_recs"]:
+        raise RecommendationError("Recommendations will not be created for this project because 'auto_apply_recs' is False")
+else:
+    raise ValueError("Job has not been properly onboarded. Cluster tags are missing")
 
 def run_job(run_job_id):
     values = {'job_id': run_job_id}
@@ -106,26 +150,51 @@ def run_job(run_job_id):
             termination_state = j['state']['result_state']
             break
     return termination_state
+
+def wait_for_recommendation(starting_recommendation_id):
+    print(f"Waiting for log submission and rec generation and application")
+    start_time = datetime.now(timezone.utc)
+    print("Start Time:", start_time)
+    current_recommendation_id = get_custom_tag_value("sync:recommendation-id")
+    #when the recommendation-id tag has been changed in the databricks job, the recommendation is complete
+    if project_id := get_custom_tag_value("sync:project-id"):
+        current_recommendation_submission_id = sync_client.get_project_recommendation(project_id, current_recommendation_id)["result"]["context"]["latest_submission_id"]
+        starting_recommendation_submission_id = sync_client.get_project_recommendation(project_id, starting_recommendation_id)["result"]["context"]["latest_submission_id"]
     
+    while current_recommendation_submission_id == starting_recommendation_submission_id:
+        time.sleep(30)
+        current_reccomendation_id = get_custom_tag_value("sync:recommendation-id")
+
+        if project_id := get_custom_tag_value("sync:project-id"):
+            current_recommendation_submission_id = sync_client.get_project_recommendation(project_id, current_reccomendation_id)["result"]["context"]["latest_submission_id"]
+            #check if a new recommendation has been created, and provide a 5 min leeway period to update the databricks job
+            if recommendations := sync_client.get_project_recommendations(get_custom_tag_value("sync:project-id"))["result"]:
+                latest_recommendation = recommendations[0]
+                if latest_recommendation["id"] != starting_recommendation_id:
+                    if latest_recommendation["state"] == 'FAILURE':
+                        raise RecommendationError("Recommendation state is FAILURE")
+                    latest_rec_created_time = parser.parse(latest_recommendation["created_at"])
+                    if (datetime.now(timezone.utc) - latest_rec_created_time).total_seconds() > 5 * 60:
+                        raise RecommendationError("Recommendation was unsuccessfully applied to databricks job")
+        
+        #timeout if it takes longer that 45 minutes
+        if (datetime.now(timezone.utc) - start_time).total_seconds() > 45 * 60:
+            raise RecommendationError("Recommendation timed out (45 minutes)")
 
 def submit_test_runs(submit_job_id, training_runs):
     current_run=1
     while current_run <= training_runs:
         print(f"Starting run {current_run} of {training_runs}")
+        current_recommendation_id = get_custom_tag_value("sync:recommendation-id")
         termination_state = run_job(run_job_id=submit_job_id)
         print(f"Run status: {termination_state}")
         if termination_state == 'SUCCESS':
             print("Completed")
             current_run = current_run + 1
-            wait_sec=1200
-            print(f"Waiting for log submission and rec generation: {wait_sec} sec")
-            time.sleep(wait_sec) #need to wait to allow logs to be submitted and rec to be generated
+            wait_for_recommendation(current_recommendation_id)
+            print("End Time:", datetime.now(timezone.utc))
         else:
             print("Unsuccessful run. Training Ended")
             current_run = training_runs + 1
 
 submit_test_runs(submit_job_id=DATABRICKS_JOB_ID, training_runs=TRAINING_RUNS)
-
-# COMMAND ----------
-
-

--- a/integration/Gradient-Train-Job.py
+++ b/integration/Gradient-Train-Job.py
@@ -154,7 +154,6 @@ def run_job(run_job_id):
 def wait_for_recommendation(starting_recommendation_id):
     print(f"Waiting for log submission and rec generation and application")
     start_time = datetime.now(timezone.utc)
-    print("Start Time:", start_time)
     current_recommendation_id = get_custom_tag_value("sync:recommendation-id")
 
     starting_recommendation_submission_id = None
@@ -198,7 +197,6 @@ def submit_test_runs(submit_job_id, training_runs):
             print("Completed")
             current_run = current_run + 1
             wait_for_recommendation(current_recommendation_id)
-            print("End Time:", datetime.now(timezone.utc))
         else:
             print("Unsuccessful run. Training Ended")
             current_run = training_runs + 1

--- a/integration/Gradient-Train-Job.py
+++ b/integration/Gradient-Train-Job.py
@@ -156,17 +156,23 @@ def wait_for_recommendation(starting_recommendation_id):
     start_time = datetime.now(timezone.utc)
     print("Start Time:", start_time)
     current_recommendation_id = get_custom_tag_value("sync:recommendation-id")
-    #when the recommendation-id tag has been changed in the databricks job, the recommendation is complete
+
+    starting_recommendation_submission_id = None
+    current_recommendation_submission_id = None
+
     if project_id := get_custom_tag_value("sync:project-id"):
-        current_recommendation_submission_id = sync_client.get_project_recommendation(project_id, current_recommendation_id)["result"]["context"]["latest_submission_id"]
-        starting_recommendation_submission_id = sync_client.get_project_recommendation(project_id, starting_recommendation_id)["result"]["context"]["latest_submission_id"]
+        if starting_recommendation_id:
+            starting_recommendation_submission_id = sync_client.get_project_recommendation(project_id, starting_recommendation_id)["result"]["context"]["latest_submission_id"]
+        if current_recommendation_id:
+            current_recommendation_submission_id = sync_client.get_project_recommendation(project_id, current_recommendation_id)["result"]["context"]["latest_submission_id"]
     
     while current_recommendation_submission_id == starting_recommendation_submission_id:
         time.sleep(30)
         current_reccomendation_id = get_custom_tag_value("sync:recommendation-id")
 
         if project_id := get_custom_tag_value("sync:project-id"):
-            current_recommendation_submission_id = sync_client.get_project_recommendation(project_id, current_reccomendation_id)["result"]["context"]["latest_submission_id"]
+            if current_recommendation_id:
+                current_recommendation_submission_id = sync_client.get_project_recommendation(project_id, current_reccomendation_id)["result"]["context"]["latest_submission_id"]
             #check if a new recommendation has been created, and provide a 5 min leeway period to update the databricks job
             if recommendations := sync_client.get_project_recommendations(get_custom_tag_value("sync:project-id"))["result"]:
                 latest_recommendation = recommendations[0]


### PR DESCRIPTION
These changes introduce a "wait_for_recommendation" function that suspends the gradient train job script until the next recommendation has been successfully created and applied to a Databricks job. Because the train job script has no knowledge of what the record_run job is doing, this is done by pinging the backend and databricks jobs api periodically. 

I also modified the cell that switches to full on demand so that it will work with both job and task clusters and changed some of the error messaging. Also made a few changes that allow it to work on Azure as well as AWS.

Finally, I added a check that makes sure that the project has auto_apply_recs enabled

Running a task cluster test here: https://dbc-d95d06ca-1d00.cloud.databricks.com/?o=656201176161048#notebook/2896071300095698/command/2896071300095706

Running a job cluster test here: https://dbc-d95d06ca-1d00.cloud.databricks.com/?o=656201176161048#notebook/2896071300095588/command/2896071300095626