### PR TITLE
Cb 37 webhook bypass in poc notebook

### DIFF
--- a/integration/Gradient-Train-Job.py
+++ b/integration/Gradient-Train-Job.py
@@ -19,7 +19,7 @@ dbutils.widgets.dropdown("Bypass Webhook", "False", ["True", "False"])
 # MAGIC  * The Gradient Webhook has been configured
 # MAGIC  * The Databricks Job has been Gradient enabled
 # MAGIC
-# MAGIC This job will confirgure all runs to execute using ON DEMAND nodes only.  The orginal settings will be restored after training is complete.
+# MAGIC This job will configure all runs to execute using ON DEMAND nodes only.  The orginal settings will be restored after training is complete.
 # MAGIC
 
 # COMMAND ----------

--- a/integration/Gradient-Train-Job.py
+++ b/integration/Gradient-Train-Job.py
@@ -52,6 +52,7 @@ from sync.models import Platform, AccessStatusCode
 import logging
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(name)s] %(message)s")
+logging.getLogger("py4j").setLevel(logging.ERROR)
 logger = logging.getLogger(__name__)
 
 platform = get_default_client().get_platform()
@@ -150,7 +151,7 @@ def submit_test_runs(submit_job_id, training_runs):
         if termination_state == 'SUCCESS':
             print("Completed")
             current_run = current_run + 1
-            wait_sec=1200
+            wait_sec=1800
             print(f"Waiting for log submission and rec generation: {wait_sec} sec")
             time.sleep(wait_sec) #need to wait to allow logs to be submitted and rec to be generated
         else:


### PR DESCRIPTION
Add option to bypass the webhook `submission -> recommendation -> update` process in the training notebook as a new boolean widget. In this case, the cycle will be executed entirely within the training notebook.

Notable things:
- `Bypass Webhook` [bool] widget. When set to False will use the Sync Runner job as before.
- `Databricks Plan` [str] widget. Needed for the webhook bypass solution
- **Runner notebook requires same IAM permissions as init_script now. The permissions test has been added to the notebook*
- Bypass only works for single-cluster jobs. Validation has been added to check this requirement.