### PR TITLE
PROD-1441: GradientML Init script can fail bootstrapping of a cluster

### DIFF
--- a/integration/gradient-agent.sh
+++ b/integration/gradient-agent.sh
@@ -17,7 +17,7 @@ for var in ${REQUIRED_ENV_VARS[*]}; do
   if [[ -z ${!var} ]]; then
     >&2 echo "$var is missing"
     >&2 print_usage
-    exit 1
+    exit
   fi
 done
 


### PR DESCRIPTION
Ticket: [PROD-1442](https://synccomputing.atlassian.net/browse/PROD-1442)

Description: 
Abnormal ran into an issue where our init script failed and this in turn failed to bootstrap their cluster. This breaks our init script design. The init script should rescue and log any exceptions and always exit with a success status code.



[PROD-1442]: https://synccomputing.atlassian.net/browse/PROD-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ