### PR TITLE
PROD-1858 Add Restart Python Kernel to record run notebook

### DIFF
--- a/integration/send-logs-gradient.py
+++ b/integration/send-logs-gradient.py
@@ -19,6 +19,10 @@
 
 # COMMAND ----------
 
+dbutils.library.restartPython()
+
+# COMMAND ----------
+
 dbutils.widgets.text("DATABRICKS_RUN_ID", "")
 dbutils.widgets.text("DATABRICKS_JOB_ID", "")
 dbutils.widgets.text("DATABRICKS_COMPUTE_TYPE", "")


### PR DESCRIPTION
This adds a cell to restart the python kernel after the pip install of our library. This is necessary to ensure all dependencies take effect from the pip install. This will also help when the library is upgraded to Pydantic 2 to avoid conflicting with the existing Pydantic 1 that comes pre installed on databricks runtimes.

[PROD-1858](https://synccomputing.atlassian.net/browse/PROD-1858)

[PROD-1858]: https://synccomputing.atlassian.net/browse/PROD-1858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ